### PR TITLE
Include array header to appease g++-12

### DIFF
--- a/src/LASlib/lasfilter.cpp
+++ b/src/LASlib/lasfilter.cpp
@@ -34,6 +34,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <array>
 #include <map>
 #include <set>
 #include <unordered_set>


### PR DESCRIPTION
While testing an upgrade of package BH against all its reverse-dependencies (see [this issue](eddelbuettel/bh#88) for details) I noticed that rlas failed to build.

The cause is unrelated to the BH upgrade and due to the fact that I ran the tests with g++-12 (on Debian testing). The newer compiler wants an explicit #include for the std::array data structure. Once that one line is added the package installs and tests fine under g++-12.

The change is very simple. It would be lovely if you could update the package at CRAN even though this is more of a g++ issue than a BH issue. 