### PR TITLE
Update readLAS.r

### DIFF
--- a/R/readLAS.r
+++ b/R/readLAS.r
@@ -115,7 +115,7 @@ read.las = function(files, select = "*", filter = "", transform = "")
 read.lasheader = function(file)
 {
   valid     <- file.exists(file)
-  supported <- tools::file_ext(file) %in% c("las", "laz", "LAS", "LAZ", "ply", "PLY")
+  supported <- tools::file_ext(file) %in% c("las", "laz", "LAS", "LAZ", "ply", "PLY", "ptx", "PTX", "txt", "TXT")
   file      <- enc2native(normalizePath(file))
 
   if (!valid)      stop("File not found", call. = F)
@@ -132,7 +132,7 @@ stream.las = function(ifiles, ofile = "", select = "*", filter = "", polygons = 
   ifiles    <- enc2native(normalizePath(ifiles))
   ofile     <- enc2native(normalizePath(ofile, mustWork = FALSE))
   valid     <- file.exists(ifiles)
-  supported <- tools::file_ext(ifiles) %in% c("las", "laz", "LAS", "LAZ", "ply", "PLY")
+  supported <- tools::file_ext(ifiles) %in% c("las", "laz", "LAS", "LAZ", "ply", "PLY", "ptx", "PTX", "txt", "TXT")
 
   if (!all(valid))      stop("File not found", call. = F)
   if (!all(supported))  stop("File not supported", call. = F)


### PR DESCRIPTION
unlocked .ptx and .txt for reading

Additionally, line 204 in lidR::io_readLAS.R will need to have ptx/PTX and txt/TXT added for this to work in lidR
"islas <- tools::file_ext(x) %in% c("las", "laz", "ply", "LAS", "LAZ", "PLY", "ptx", "PTX", "txt", "TXT")"

tested it with a few .ptx and .txt files and while it read and plotted fine, it did result in a few quantization errors but that's on the user who provides the file. 

![image](https://github.com/user-attachments/assets/dcd37453-8890-430c-b696-266aca520d77)
