### PR TITLE
fix read.lasheader for signed URL

### DIFF
--- a/R/readLAS.r
+++ b/R/readLAS.r
@@ -125,7 +125,8 @@ read.lasheader = function(file)
   else
   {
     valid <- TRUE
-    supported <- tools::file_ext(file) %in% c("las", "laz", "LAS", "LAZ")
+    clean_path <- sub("\\?.*$", "", file)
+    supported <- tools::file_ext(clean_path) %in% c("las", "laz", "LAS", "LAZ")
     file  <- enc2native(file)
   }
 


### PR DESCRIPTION
Hi @Jean-Romain,
First, many thanks for that new version of `rlas` supporting the reading of remote files (headers and data), what a job!
It has been a while I was thinking about it, but never had the courage to enter that far in the code.

I just tested, it works pretty well for COPC URLs with public access, but the `read.header` fails the test on the extension for signed URLs, due to signing query parameters.

This extends the subtraction of `read.las` to `read.header`.
A similar PR is suggested in `lidR` to make it fully compatible with signed URLs (`catalog` and `streamLAS`)